### PR TITLE
fix: preserve literal types in Infer by using const type parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,13 @@ runtyp is designed for speed. Here's how it compares to other popular programmat
 npm i runtyp
 ```
 
+## Requirements
+
+- **Node.js**: 18+ (or any modern browser)
+- **TypeScript**: 5.0+ (for type inference features)
+
+> **Note**: JavaScript users can use runtyp without TypeScript. The TypeScript requirement only applies if you want type inference via `Infer<>`.
+
 # Usage
 
 ## Example

--- a/package.json
+++ b/package.json
@@ -36,6 +36,14 @@
     "lint": "eslint ./ --ext .js,.ts",
     "build": "tsc"
   },
+  "peerDependencies": {
+    "typescript": ">=5.0.0"
+  },
+  "peerDependenciesMeta": {
+    "typescript": {
+      "optional": true
+    }
+  },
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^5.59.2",
     "@typescript-eslint/parser": "^5.59.2",

--- a/src/predicates/literal.spec.ts
+++ b/src/predicates/literal.spec.ts
@@ -1,5 +1,18 @@
 import {test} from 'kizu';
 import {literal} from './literal';
+import type {Infer} from '..';
+
+// Type-level test: Infer should preserve literal types
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const textValidator = literal('text');
+
+type TextType = Infer<typeof textValidator>;
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars, no-underscore-dangle
+const typeTest: TextType = 'text';
+// @ts-expect-error - 'other' is not assignable to 'text'
+// eslint-disable-next-line @typescript-eslint/no-unused-vars, no-underscore-dangle
+const typeTestFail: TextType = 'other';
 
 test('literal(): valid inputs', (assert) => {
 

--- a/src/predicates/literal.ts
+++ b/src/predicates/literal.ts
@@ -1,6 +1,6 @@
 import {Pred, ValidationResult} from '..';
 
-export function literal<T extends any>(expected: T): Pred<T> {
+export function literal<const T>(expected: T): Pred<T> {
 
     return (value: unknown): ValidationResult<T> => {
 


### PR DESCRIPTION
Use TypeScript 5.0's `const` type parameter modifier to preserve literal types through inference. Previously, `literal('text')` would infer as `string` instead of `'text'`, breaking discriminated union narrowing.

Before:
  const v = literal('text');
  type T = Infer<typeof v>; // string

After:
  const v = literal('text');
  type T = Infer<typeof v>; // 'text'

This removes the need for callers to use `as const` at call sites.