### PR TITLE
ci: enable npm provenance for package attestation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,7 @@ on:
 permissions:
       contents: write
       packages: write
+      id-token: write  # Required for npm provenance
 jobs:
   release:
     name: release
@@ -38,3 +39,4 @@ jobs:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
           NPM_TOKEN: ${{secrets.NPM_TOKEN}}
+          NPM_CONFIG_PROVENANCE: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,6 +37,4 @@ jobs:
       - run: npx autorel@^2
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
-          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
-          NPM_TOKEN: ${{secrets.NPM_TOKEN}}
           NPM_CONFIG_PROVENANCE: true


### PR DESCRIPTION
- Add id-token: write permission for OIDC
- Set NPM_CONFIG_PROVENANCE=true for verified provenance

This adds a verified 'Published from github.com/logspacehq/runtyp' badge on npm.