### PR TITLE
ci: only run checks on pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,6 @@ name: CI
 on:
   pull_request:
     branches: [main, next]
-  push:
-    branches: [main, next]
 
 jobs:
   test:


### PR DESCRIPTION
Remove push trigger for main/next branches since the release workflow handles those separately. This avoids redundant CI runs on merge.