### PR TITLE
docs: file size title + fix npm OIDC (package.json repo URL)

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![License](https://img.shields.io/badge/License-MIT-blue.svg)](https://opensource.org/licenses/MIT)
 [![AutoRel](https://img.shields.io/badge/%F0%9F%9A%80%20AutoRel-2D4DDE)](https://github.com/mhweiner/autorel)
 
-Lightning-fast, zero-dependency runtime type validation for TS/JS. 25x faster than zod with a cleaner API.
+Lightning-fast, zero-dependency runtime type validation for TS/JS. 25x faster and 15x smaller than zod (4kb vs 60kb gzipped).
 
 **🚀 Fast & reliable performance**  
 

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "runtyp",
   "version": "1.0.0",
-  "description": "Lightning-fast, zero-dependency runtime validation for TS/JS. 25x faster than zod with a cleaner API.",
-  "keywords": [
+    "description": "Lightning-fast, zero-dependency runtime validation for TS/JS. 25x faster and 15x smaller than zod (4kb vs 60kb gzipped).",
+    "keywords": [
     "joi",
     "zod",
     "myzod",

--- a/package.json
+++ b/package.json
@@ -15,9 +15,9 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/logspacehq/runtyp.git"
+    "url": "git+https://github.com/logfoxai/runtyp.git"
   },
-  "homepage": "https://github.com/logspacehq/runtyp",
+  "homepage": "https://github.com/logfoxai/runtyp",
   "license": "MIT",
   "author": "Marc H. Weiner <mhweiner234@gmail.com>",
   "publishConfig": {


### PR DESCRIPTION
**Docs**
- Tweak README title to reflect file size advantages over zod.

**Deploy fix**
- Update `package.json` `repository.url` and `homepage` from `logspacehq/runtyp` to `logfoxai/runtyp`.
- Repo moved; npm trusted publishing (OIDC) requires the repo in package.json to match the GitHub repo, so the mismatch was causing publish to fail.